### PR TITLE
waydroid: Optionally start CCodec service from /vendor_extra

### DIFF
--- a/rootdir/etc/init.waydroid.rc
+++ b/rootdir/etc/init.waydroid.rc
@@ -44,3 +44,11 @@ service vendor.camera-provider-2-4 /vendor/bin/hw/android.hardware.camera.provid
     capabilities SYS_NICE
     oneshot
     writepid /dev/cpuset/camera-daemon/tasks /dev/stune/top-app/tasks
+
+service vendor-qti-media-c2-hal-1-0 /vendor_extra/bin/hw/vendor.qti.media.c2@1.0-service
+    override
+    class hal
+    user mediacodec
+    group mediadrm camera drmrpc system
+    ioprio rt 4
+    writepid /dev/cpuset/foreground/tasks


### PR DESCRIPTION
On the Pixel 3a with Ubuntu Touch CCodec is used on the host
as determined by debug.stagefright.ccodec=4.

This has the weird effect of starting the missing services
for multimedia playback, but using OMX in the end since.. why not?

For completeness sake, and since on the host both OMX and C2 are
running anyway, just start C2 inside of the WayDroid container as well.