### PR TITLE
rootdir: Ship dummy libnfc-nci.conf

### DIFF
--- a/product.mk
+++ b/product.mk
@@ -22,6 +22,10 @@ PRODUCT_COPY_FILES += \
 PRODUCT_PACKAGES += \
     init.waydroid.rc
 
+# Dummy libnfc-nci.conf
+PRODUCT_PACKAGES += \
+    libnfc-nci.conf
+
 # Properties
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/waydroid.prop:$(TARGET_COPY_OUT_VENDOR)/waydroid.prop

--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -7,3 +7,11 @@ LOCAL_MODULE_CLASS      := ETC
 LOCAL_SRC_FILES         := etc/init.waydroid.rc
 LOCAL_MODULE_PATH       := $(TARGET_OUT_ETC)/init
 include $(BUILD_PREBUILT)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE            := libnfc-nci.conf
+LOCAL_MODULE_TAGS       := optional
+LOCAL_MODULE_CLASS      := ETC
+LOCAL_SRC_FILES         := etc/libnfc-nci.conf
+LOCAL_MODULE_PATH       := $(TARGET_OUT_ETC)
+include $(BUILD_PREBUILT)


### PR DESCRIPTION
In order to allow libnfc-nci.conf to be bind-mounted over it
needs the file to exist in the target inside of the container.
Ship an empty libnfc-nci.conf file for that purpose.