### PR TITLE
manifests: Use new repos for chromium-webview

### DIFF
--- a/manifest_scripts/manifests/00-remotes.xml
+++ b/manifest_scripts/manifests/00-remotes.xml
@@ -2,5 +2,6 @@
 <manifest>
   <!-- Remotes -->
   <remote name="ghub" fetch="https://github.com/" />
+  <remote name="gitlab" fetch="https://gitlab.com/" />
 
 </manifest>

--- a/manifest_scripts/manifests/01-removes.xml
+++ b/manifest_scripts/manifests/01-removes.xml
@@ -5,5 +5,6 @@
   <remove-project name="platform/external/mesa3d" />
   <remove-project name="platform/hardware/intel/common/libva" />
   <remove-project name="LineageOS/android_packages_apps_SetupWizard" />
+  <remove-project name="LineageOS/android_external_chromium-webview" />
 
 </manifest>

--- a/manifest_scripts/manifests/02-waydroid.xml
+++ b/manifest_scripts/manifests/02-waydroid.xml
@@ -25,4 +25,15 @@
   <!-- BoringDroid -->
   <project path="vendor/prebuilts/bdapps" name="boringdroid/vendor_prebuilts_bdapps" remote="ghub" revision="refs/heads/boringdroid-10.0.0" />
 
+  <!-- Webview -->
+  <project path="external/chromium-webview/patches" name="LineageOS/android_external_chromium-webview_patches" remote="ghub" revision="main" >
+    <linkfile src="Android.mk" dest="external/chromium-webview/Android.mk" />
+    <linkfile src="CleanSpec.mk" dest="external/chromium-webview/CleanSpec.mk" />
+    <linkfile src="README" dest="external/chromium-webview/README" />
+  </project>
+  <project path="external/chromium-webview/prebuilt/arm" name="LineageOS/android_external_chromium-webview_prebuilt_arm" clone-depth="1" remote="ghub" revision="main" />
+  <project path="external/chromium-webview/prebuilt/arm64" name="LineageOS/android_external_chromium-webview_prebuilt_arm64" clone-depth="1" remote="ghub" revision="main" />
+  <project path="external/chromium-webview/prebuilt/x86" name="LineageOS/android_external_chromium-webview_prebuilt_x86" clone-depth="1" remote="ghub" revision="main" />
+  <project path="external/chromium-webview/prebuilt/x86_64" name="LineageOS/android/android_external_chromium-webview_prebuilt_x86_64" clone-depth="1" remote="gitlab" revision="main"  />
+
 </manifest>


### PR DESCRIPTION
Upstream split the repos for space constraints:
x86_64 was moved to gitlab because the apk is bigger than 100MB

Change-Id: Ia4f357299fcb8f660832fe097d283c35fb4f9d86