### PR TITLE
Revert "waydroid: Optionally start CCodec service from /vendor_extra"

### DIFF
--- a/rootdir/etc/init.waydroid.rc
+++ b/rootdir/etc/init.waydroid.rc
@@ -44,11 +44,3 @@ service vendor.camera-provider-2-4 /vendor/bin/hw/android.hardware.camera.provid
     capabilities SYS_NICE
     oneshot
     writepid /dev/cpuset/camera-daemon/tasks /dev/stune/top-app/tasks
-
-service vendor-qti-media-c2-hal-1-0 /vendor_extra/bin/hw/vendor.qti.media.c2@1.0-service
-    override
-    class hal
-    user mediacodec
-    group mediadrm camera drmrpc system
-    ioprio rt 4
-    writepid /dev/cpuset/foreground/tasks


### PR DESCRIPTION
On Ubuntu Touch for the Pixel 3a and the Fairphone 4 the old ACodec stagefright codepaths are prefered,
so avoid trying to launch a service for which the necessary libraries are not available.

Reverts waydroid/android_vendor_waydroid#1