### PR TITLE
init.waydroid.rc: Neutralize CCodec on Android 9

### DIFF
--- a/rootdir/etc/init.waydroid.rc
+++ b/rootdir/etc/init.waydroid.rc
@@ -44,3 +44,6 @@ service vendor.camera-provider-2-4 /vendor/bin/hw/android.hardware.camera.provid
     capabilities SYS_NICE
     oneshot
     writepid /dev/cpuset/camera-daemon/tasks /dev/stune/top-app/tasks
+
+on property:ro.vndk.version=28
+    mount none /dev/null /vendor_extra/lib/libmedia_codecserviceregistrant.so ro bind


### PR DESCRIPTION
CCodec is unusable and conflicts with OMX on Android 9 devices.
Instead of hosting the IOmxStore interface using C2, just neutralize
the library responsible for registering C2 altogether.

Fixes HW audio/video on Android 9 vendors like the Pixel 3a.