### PR TITLE
Allow to unconditionally hide status bar in app mode

### DIFF
--- a/waydroid-patches/base-patches-30/frameworks/base/0036-Force-hide-status-bar-in-multi-windows-mode.patch
+++ b/waydroid-patches/base-patches-30/frameworks/base/0036-Force-hide-status-bar-in-multi-windows-mode.patch
@@ -52,7 +52,7 @@ index 81378831adbc..78a0a46e86d3 100644
 +    public static boolean shouldForceHide(@InternalInsetsType int type) {
 +        return (type == ITYPE_CLIMATE_BAR ||
 +                type == ITYPE_STATUS_BAR) &&
-+            BoringdroidManager.isPCModeEnabled() &&
++            (BoringdroidManager.isPCModeEnabled() || SystemProperties.getBoolean("persist.waydroid.hide_status_bar", false)) &&
 +            !"Waydroid".equals(SystemProperties.get("waydroid.active_apps"));
 +    }
 +


### PR DESCRIPTION
Make it configurable, as this makes the status bar inaccessible.

---

FWIW, I am using this together with gesture-based navigation to effectively hide both status and navigation bars while in app mode, keeping the back button available as a gesture.