### PR TITLE
rootdir: Fixup hwcomposer Wayland connection for UT focal+

### DIFF
--- a/rootdir/etc/init.waydroid.rc
+++ b/rootdir/etc/init.waydroid.rc
@@ -37,7 +37,7 @@ service vendor.audio-hal /vendor/bin/hw/android.hardware.audio.service
     task_profiles ProcessCapacityHigh HighPerformance
     onrestart restart audioserver
 
-service vendor.hwcomposer-2-1 /vendor/bin/hw/android.hardware.graphics.composer@2.1-service --desktop_file_hint=unity8.desktop
+service vendor.hwcomposer-2-1 /vendor/bin/hw/android.hardware.graphics.composer@2.1-service --desktop_file_hint=Waydroid.desktop
     override
     class hal animation
     user host


### PR DESCRIPTION
The unity8.desktop file has been renamed to lomiri.desktop, hence cannot be found on newer Ubuntu Touch.
Point the desktop_file_hint to the valid one for Waydroid itself, to stay independent of the host OS version.