### PR TITLE
Mount proc with the hidepid=2 option

### DIFF
--- a/product.mk
+++ b/product.mk
@@ -22,6 +22,9 @@ PRODUCT_COPY_FILES += \
 PRODUCT_PACKAGES += \
     init.waydroid.rc
 
+PRODUCT_PACKAGES += \
+    hidepid.rc
+
 # Dummy libnfc-nci.conf
 PRODUCT_PACKAGES += \
     libnfc-nci.conf

--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -9,6 +9,14 @@ LOCAL_MODULE_PATH       := $(TARGET_OUT_ETC)/init
 include $(BUILD_PREBUILT)
 
 include $(CLEAR_VARS)
+LOCAL_MODULE            := hidepid.rc
+LOCAL_MODULE_TAGS       := optional
+LOCAL_MODULE_CLASS      := ETC
+LOCAL_SRC_FILES         := etc/hidepid.rc
+LOCAL_MODULE_PATH       := $(TARGET_OUT_ETC)/init
+include $(BUILD_PREBUILT)
+
+include $(CLEAR_VARS)
 LOCAL_MODULE            := libnfc-nci.conf
 LOCAL_MODULE_TAGS       := optional
 LOCAL_MODULE_CLASS      := ETC

--- a/rootdir/etc/hidepid.rc
+++ b/rootdir/etc/hidepid.rc
@@ -1,0 +1,2 @@
+on init
+    exec -- /system/bin/toybox mount -o remount,hidepid=2 /proc


### PR DESCRIPTION
Hello, everyone! Last year I've proposed [mounting ```/proc``` with the ```hidepid=2``` option](https://github.com/waydroid/waydroid/pull/523) (the way it's done on smartphones). It was merged, but soon [reverted due to another security issue it caused](https://github.com/waydroid/waydroid/commit/0ad842a015c5153880b377bf7fa5572504339df5). In this pull request, I propose another approach -- remounting the ```/proc``` with this option by an init file inside the Android system after the container has started. This gets ```/proc``` mounted with ```hidepid=2``` while keeping the mixed mount (with ```/proc/sys``` mounted as read-only).