### PR TITLE
Unconditional privilege dropping in ADBD

### DIFF
--- a/waydroid-patches/base-patches-30/system/core/0014-Block-adb-root-unconditionally.patch
+++ b/waydroid-patches/base-patches-30/system/core/0014-Block-adb-root-unconditionally.patch
@@ -1,0 +1,50 @@
+From 520d26c219bb6ec09de7cc732173569d64599f90 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=D0=90=D0=B7=D0=B0=D0=BB=D0=B8=D1=8F=20=D0=A1=D0=BC=D0=B0?=
+ =?UTF-8?q?=D1=80=D0=B0=D0=B3=D0=B4=D0=BE=D0=B2=D0=B0?=
+ <charming.flurry@yandex.ru>
+Date: Wed, 26 Jul 2023 15:24:18 +0000
+Subject: [PATCH] Patching ADBD in order to drop privileges unconditionally.
+
+Change-Id: I038d96fe58a81dbbb56013df7010e80ee29b0d82
+---
+ adb/daemon/main.cpp            | 5 +++++
+ adb/daemon/restart_service.cpp | 7 +++++++
+ 2 files changed, 12 insertions(+)
+
+diff --git a/adb/daemon/main.cpp b/adb/daemon/main.cpp
+index c3feecd56..e045bdcff 100644
+--- a/adb/daemon/main.cpp
++++ b/adb/daemon/main.cpp
+@@ -63,6 +63,11 @@
+ static const char* root_seclabel = nullptr;
+ 
+ static bool should_drop_privileges() {
++    // Always dropping privileges in Waydroid because the daemon will interact with unprivileged users
++    if (true) {
++        return true;
++    }
++
+     // The properties that affect `adb root` and `adb unroot` are ro.secure and
+     // ro.debuggable. In this context the names don't make the expected behavior
+     // particularly obvious.
+diff --git a/adb/daemon/restart_service.cpp b/adb/daemon/restart_service.cpp
+index c942c1f23..cbac6fde8 100644
+--- a/adb/daemon/restart_service.cpp
++++ b/adb/daemon/restart_service.cpp
+@@ -34,6 +34,13 @@
+ #include "adb_unique_fd.h"
+ 
+ void restart_root_service(unique_fd fd) {
++    // Running ADBD as root is not safe in Waydroid, since it allows an unprivileged user to get an actual root shell (however, with restrictions enabled by LXC) with no way for admin to stop.
++    // There are other ways to perform privileged tasks, for "waydroid shell" subcommand to Magisk, that require either root or initial privileged setup
++    if (true) {
++        WriteFdExactly(fd.get(), "not available in Waydroid\n");
++        return;
++    }
++
+     if (getuid() == 0) {
+         WriteFdExactly(fd.get(), "adbd is already running as root\n");
+         return;
+-- 
+2.41.0
+


### PR DESCRIPTION
Hello everyone! I propose patching ADBD to unconditionally block restarting as root.

The reason for unconditionally blocking restarting ADBD as root is that it allows an unprivileged user to enable the "Rooted debugging" option and use the adb root command in order to get root shell (and it runs as an actual root UID since the container is privileged, however, it's restricted due to security options enabled in LXC container config), and there is no way for the administrator to prevent that. Privileged things that require root can be done with the waydroid shell subcommand (or with Magisk) that require either root, or initial privileged setup.