### PR TITLE
Stop security hardening on proc dir

### DIFF
--- a/rootdir/etc/hidepid.rc
+++ b/rootdir/etc/hidepid.rc
@@ -1,2 +1,0 @@
-on init
-    exec -- /system/bin/toybox mount -o remount,hidepid=2 /proc


### PR DESCRIPTION
Using hidepid=2 option on /proc could make system services into a blackhole. For instance, lmkd needs looking up all processes currently working in the system. But with the option, it's impossible maintaining processes.

If anyone needs the option, it better uses lxc.mount.entry option instead.