### PR TITLE
patches-30: Add force_mouse_as_touch option.

### DIFF
--- a/waydroid-patches/base-patches-30/frameworks/base/0051-Force-mouse-event-as-touch-1-2.patch
+++ b/waydroid-patches/base-patches-30/frameworks/base/0051-Force-mouse-event-as-touch-1-2.patch
@@ -1,0 +1,212 @@
+From bb6f3ff35f7c3f43df995f976155e2f0c15ea57e Mon Sep 17 00:00:00 2001
+From: YogSottot <7411302+YogSottot@users.noreply.github.com>
+Date: Sat, 25 May 2024 10:04:11 +0300
+Subject: [PATCH] Force mouse event as touch [1/2]
+
+Change-Id: Ie914d51d76e724b86e44a98e389f5a7b344fa157
+---
+ core/java/android/provider/Settings.java      |  7 ++++
+ .../server/input/InputManagerService.java     | 32 +++++++++++++++++++
+ ...droid_server_input_InputManagerService.cpp | 27 ++++++++++++++++
+ 3 files changed, 66 insertions(+)
+
+diff --git a/core/java/android/provider/Settings.java b/core/java/android/provider/Settings.java
+index fe61bc37d22..1cd317a363f 100755
+--- a/core/java/android/provider/Settings.java
++++ b/core/java/android/provider/Settings.java
+@@ -4785,6 +4785,11 @@ public final class Settings {
+          */
+         public static final String EGG_MODE = "egg_mode";
+ 
++        /**
++         * @hide
++         */
++        public static final String FORCE_MOUSE_AS_TOUCH = "force_mouse_as_touch";
++
+         /**
+          * Setting to determine whether or not to show the battery percentage in the status bar.
+          *    0 - Don't show percentage
+@@ -4927,6 +4932,7 @@ public final class Settings {
+             PRIVATE_SETTINGS.add(EGG_MODE);
+             PRIVATE_SETTINGS.add(SHOW_BATTERY_PERCENT);
+             PRIVATE_SETTINGS.add(DISPLAY_COLOR_MODE);
++            PRIVATE_SETTINGS.add(FORCE_MOUSE_AS_TOUCH);
+         }
+ 
+         /**
+@@ -4941,6 +4947,7 @@ public final class Settings {
+             CLONE_TO_MANAGED_PROFILE.add(SOUND_EFFECTS_ENABLED);
+             CLONE_TO_MANAGED_PROFILE.add(TEXT_SHOW_PASSWORD);
+             CLONE_TO_MANAGED_PROFILE.add(TIME_12_24);
++            CLONE_TO_MANAGED_PROFILE.add(FORCE_MOUSE_AS_TOUCH);
+         }
+ 
+         /** @hide */
+diff --git a/services/core/java/com/android/server/input/InputManagerService.java b/services/core/java/com/android/server/input/InputManagerService.java
+index 963f677178a..dd49cfcfd53 100644
+--- a/services/core/java/com/android/server/input/InputManagerService.java
++++ b/services/core/java/com/android/server/input/InputManagerService.java
+@@ -232,6 +232,7 @@ public class InputManagerService extends IInputManager.Stub
+     private static native boolean nativeTransferTouchFocus(long ptr,
+             IBinder fromChannelToken, IBinder toChannelToken);
+     private static native void nativeSetPointerSpeed(long ptr, int speed);
++    private static native void nativeSetForceMouseAsTouch(long ptr, boolean forceMouseAsTouch);
+     private static native void nativeSetShowTouches(long ptr, boolean enabled);
+     private static native void nativeSetVolumeKeysRotation(long ptr, int mode);
+     private static native void nativeSetInteractive(long ptr, boolean interactive);
+@@ -361,6 +362,7 @@ public class InputManagerService extends IInputManager.Stub
+         Watchdog.getInstance().addMonitor(this);
+ 
+         registerPointerSpeedSettingObserver();
++        registerForceMouseAsTouchSettingObserver();
+         registerShowTouchesSettingObserver();
+         registerAccessibilityLargePointerSettingObserver();
+         registerLongPressTimeoutObserver();
+@@ -370,6 +372,7 @@ public class InputManagerService extends IInputManager.Stub
+             @Override
+             public void onReceive(Context context, Intent intent) {
+                 updatePointerSpeedFromSettings();
++                updateForceMouseAsTouchFromSettings();
+                 updateShowTouchesFromSettings();
+                 updateAccessibilityLargePointerFromSettings();
+                 updateDeepPressStatusFromSettings("user switched");
+@@ -378,6 +381,7 @@ public class InputManagerService extends IInputManager.Stub
+         }, new IntentFilter(Intent.ACTION_USER_SWITCHED), null, mHandler);
+ 
+         updatePointerSpeedFromSettings();
++        updateForceMouseAsTouchFromSettings();
+         updateShowTouchesFromSettings();
+         updateAccessibilityLargePointerFromSettings();
+         updateDeepPressStatusFromSettings("just booted");
+@@ -1630,6 +1634,14 @@ public class InputManagerService extends IInputManager.Stub
+                 InputManager.MAX_POINTER_SPEED);
+         nativeSetPointerSpeed(mPtr, speed);
+     }
++    
++    private void updateForceMouseAsTouchFromSettings() {
++        boolean forceMouseAsTouch = getForceMouseAsTouchSetting();
++        setForceMouseAsTouchUnchecked(forceMouseAsTouch);
++    }
++    private void setForceMouseAsTouchUnchecked(boolean forceMouseAsTouch) {
++        nativeSetForceMouseAsTouch(mPtr, forceMouseAsTouch);
++    }
+ 
+     private void registerPointerSpeedSettingObserver() {
+         mContext.getContentResolver().registerContentObserver(
+@@ -1651,6 +1663,26 @@ public class InputManagerService extends IInputManager.Stub
+         }
+         return speed;
+     }
++    
++    private void registerForceMouseAsTouchSettingObserver() {
++        mContext.getContentResolver().registerContentObserver(
++                Settings.System.getUriFor(Settings.System.FORCE_MOUSE_AS_TOUCH), true,
++                new ContentObserver(mHandler) {
++                    @Override
++                    public void onChange(boolean selfChange) {
++                        updateForceMouseAsTouchFromSettings();
++                    }
++                }, UserHandle.USER_ALL);
++    }
++    private boolean getForceMouseAsTouchSetting() {
++        boolean forceMouseAsTouch = false;
++        try {
++            forceMouseAsTouch = Settings.System.getIntForUser(mContext.getContentResolver(),
++                    Settings.System.FORCE_MOUSE_AS_TOUCH, UserHandle.USER_CURRENT) > 0;
++        } catch (SettingNotFoundException ignored) {
++        }
++        return forceMouseAsTouch;
++    }
+ 
+     private void updateShowTouchesFromSettings() {
+         int setting = getShowTouchesSetting(0);
+diff --git a/services/core/jni/com_android_server_input_InputManagerService.cpp b/services/core/jni/com_android_server_input_InputManagerService.cpp
+index 396d67af9ba..c3330f2e73e 100644
+--- a/services/core/jni/com_android_server_input_InputManagerService.cpp
++++ b/services/core/jni/com_android_server_input_InputManagerService.cpp
+@@ -212,6 +212,7 @@ public:
+     void setInputDispatchMode(bool enabled, bool frozen);
+     void setSystemUiVisibility(int32_t visibility);
+     void setPointerSpeed(int32_t speed);
++    void setForceMouseAsTouch(bool forceMouseAsTouch);
+     void setInputDeviceEnabled(uint32_t deviceId, bool enabled);
+     void setShowTouches(bool enabled);
+     void setVolumeKeysRotation(int mode);
+@@ -286,6 +287,9 @@ private:
+ 
+         // Pointer speed.
+         int32_t pointerSpeed;
++        
++        // Force mouse events to be handled as touch event.
++        bool forceMouseAsTouch;
+ 
+         // True if pointer gestures are enabled.
+         bool pointerGesturesEnabled;
+@@ -339,6 +343,7 @@ NativeInputManager::NativeInputManager(jobject contextObj,
+         AutoMutex _l(mLock);
+         mLocked.systemUiVisibility = ASYSTEM_UI_VISIBILITY_STATUS_BAR_VISIBLE;
+         mLocked.pointerSpeed = 0;
++        mLocked.forceMouseAsTouch = false;
+         mLocked.pointerGesturesEnabled = true;
+         mLocked.showTouches = false;
+         mLocked.pointerCapture = false;
+@@ -368,6 +373,7 @@ void NativeInputManager::dump(std::string& dump) {
+         dump += StringPrintf(INDENT "System UI Visibility: 0x%0" PRIx32 "\n",
+                 mLocked.systemUiVisibility);
+         dump += StringPrintf(INDENT "Pointer Speed: %" PRId32 "\n", mLocked.pointerSpeed);
++        dump += StringPrintf(INDENT "Force Mouse As Touch: %s\n", toString(mLocked.forceMouseAsTouch));
+         dump += StringPrintf(INDENT "Pointer Gestures Enabled: %s\n",
+                 toString(mLocked.pointerGesturesEnabled));
+         dump += StringPrintf(INDENT "Show Touches: %s\n", toString(mLocked.showTouches));
+@@ -535,6 +541,7 @@ void NativeInputManager::getReaderConfiguration(InputReaderConfiguration* outCon
+ 
+         outConfig->pointerVelocityControlParameters.scale = exp2f(mLocked.pointerSpeed
+                 * POINTER_SPEED_EXPONENT);
++        outConfig->forceMouseAsTouch = mLocked.forceMouseAsTouch;
+         outConfig->pointerGesturesEnabled = mLocked.pointerGesturesEnabled;
+ 
+         outConfig->showTouches = mLocked.showTouches;
+@@ -836,6 +843,19 @@ void NativeInputManager::setPointerSpeed(int32_t speed) {
+             InputReaderConfiguration::CHANGE_POINTER_SPEED);
+ }
+ 
++void NativeInputManager::setForceMouseAsTouch(bool forceMouseAsTouch) {
++    { // acquire lock
++        AutoMutex _l(mLock);
++        if (mLocked.forceMouseAsTouch == forceMouseAsTouch) {
++            return;
++        }
++        ALOGI("Setting force mouse as touch to %s.", toString(forceMouseAsTouch));
++        mLocked.forceMouseAsTouch = forceMouseAsTouch;
++    } // release lock
++    mInputManager->getReader()->requestRefreshConfiguration(
++        InputReaderConfiguration::CHANGE_FORCE_MOUSE_AS_TOUCH);
++}
++
+ void NativeInputManager::setInputDeviceEnabled(uint32_t deviceId, bool enabled) {
+     { // acquire lock
+         AutoMutex _l(mLock);
+@@ -1619,6 +1639,12 @@ static void nativeSetPointerSpeed(JNIEnv* /* env */,
+     im->setPointerSpeed(speed);
+ }
+ 
++static void nativeSetForceMouseAsTouch(JNIEnv* /* env */,
++                                       jclass /* clazz */, jlong ptr, jboolean forceMouseAsTouch) {
++    NativeInputManager* im = reinterpret_cast<NativeInputManager*>(ptr);
++    im->setForceMouseAsTouch(forceMouseAsTouch);
++}
++
+ static void nativeSetShowTouches(JNIEnv* /* env */,
+         jclass /* clazz */, jlong ptr, jboolean enabled) {
+     NativeInputManager* im = reinterpret_cast<NativeInputManager*>(ptr);
+@@ -1817,6 +1843,7 @@ static const JNINativeMethod gInputManagerMethods[] = {
+         {"nativeTransferTouchFocus", "(JLandroid/os/IBinder;Landroid/os/IBinder;)Z",
+          (void*)nativeTransferTouchFocus},
+         {"nativeSetPointerSpeed", "(JI)V", (void*)nativeSetPointerSpeed},
++        {"nativeSetForceMouseAsTouch", "(JZ)V", (void*)nativeSetForceMouseAsTouch},
+         {"nativeSetShowTouches", "(JZ)V", (void*)nativeSetShowTouches},
+         {"nativeSetVolumeKeysRotation", "(JI)V", (void*)nativeSetVolumeKeysRotation},
+         {"nativeSetInteractive", "(JZ)V", (void*)nativeSetInteractive},
+-- 
+2.25.1
+

--- a/waydroid-patches/base-patches-30/frameworks/base/0051-Force-mouse-event-as-touch-1-2.patch
+++ b/waydroid-patches/base-patches-30/frameworks/base/0051-Force-mouse-event-as-touch-1-2.patch
@@ -82,7 +82,7 @@ index 963f677178a..dd49cfcfd53 100644
                  InputManager.MAX_POINTER_SPEED);
          nativeSetPointerSpeed(mPtr, speed);
      }
-+    
++
 +    private void updateForceMouseAsTouchFromSettings() {
 +        boolean forceMouseAsTouch = getForceMouseAsTouchSetting();
 +        setForceMouseAsTouchUnchecked(forceMouseAsTouch);
@@ -97,7 +97,7 @@ index 963f677178a..dd49cfcfd53 100644
          }
          return speed;
      }
-+    
++
 +    private void registerForceMouseAsTouchSettingObserver() {
 +        mContext.getContentResolver().registerContentObserver(
 +                Settings.System.getUriFor(Settings.System.FORCE_MOUSE_AS_TOUCH), true,
@@ -136,7 +136,7 @@ index 396d67af9ba..c3330f2e73e 100644
  
          // Pointer speed.
          int32_t pointerSpeed;
-+        
++
 +        // Force mouse events to be handled as touch event.
 +        bool forceMouseAsTouch;
  

--- a/waydroid-patches/base-patches-30/frameworks/native/0015-Force-mouse-event-as-touch-2-2.patch
+++ b/waydroid-patches/base-patches-30/frameworks/native/0015-Force-mouse-event-as-touch-2-2.patch
@@ -48,7 +48,7 @@ index 879d26de3..835a239cd 100644
  
          // All devices must be reopened.
          CHANGE_MUST_REOPEN = 1 << 31,
-+        
++
 +        // Force mouse as touch setting changed.
 +        CHANGE_FORCE_MOUSE_AS_TOUCH = 1 << 90,
      };
@@ -58,7 +58,7 @@ index 879d26de3..835a239cd 100644
  
      // True if pointer gestures are enabled.
      bool pointerGesturesEnabled;
-+    
++
 +    // True if pointer touch emulation is enabled.
 +    bool forceMouseAsTouch;
  
@@ -105,7 +105,7 @@ index 6f9fb1b5c..f3f0d81c7 100644
          mWheelXVelocityControl.setParameters(config->wheelVelocityControlParameters);
          mWheelYVelocityControl.setParameters(config->wheelVelocityControlParameters);
      }
-+    
++
 +    if (!changes || (changes & InputReaderConfiguration::CHANGE_FORCE_MOUSE_AS_TOUCH)) {
 +        if (mParameters.mode == Parameters::MODE_POINTER_RELATIVE) {
 +            // Disable touch emulation for the pointer when Pointer Capture is enabled.

--- a/waydroid-patches/base-patches-30/frameworks/native/0015-Force-mouse-event-as-touch-2-2.patch
+++ b/waydroid-patches/base-patches-30/frameworks/native/0015-Force-mouse-event-as-touch-2-2.patch
@@ -1,0 +1,151 @@
+From 6059542937bbe83ce8e6090bbe2bbb10d1bda9e6 Mon Sep 17 00:00:00 2001
+From: YogSottot <7411302+YogSottot@users.noreply.github.com>
+Date: Sat, 25 May 2024 10:09:02 +0300
+Subject: [PATCH] Force mouse event as touch [2/2]
+
+Change-Id: Id15222e62490bb1ae863fc2c7e96e4c5e5f40ce7
+---
+ services/inputflinger/InputReaderBase.cpp     |  3 +++
+ .../dispatcher/InputDispatcher.cpp            |  3 +--
+ .../inputflinger/include/InputReaderBase.h    |  7 ++++++
+ services/inputflinger/reader/InputReader.cpp  |  1 +
+ .../reader/mapper/CursorInputMapper.cpp       | 23 +++++++++++++++----
+ 5 files changed, 31 insertions(+), 6 deletions(-)
+
+diff --git a/services/inputflinger/InputReaderBase.cpp b/services/inputflinger/InputReaderBase.cpp
+index b2dadf846..a5b1e00b3 100644
+--- a/services/inputflinger/InputReaderBase.cpp
++++ b/services/inputflinger/InputReaderBase.cpp
+@@ -52,6 +52,9 @@ std::string InputReaderConfiguration::changesToString(uint32_t changes) {
+     if (changes & CHANGE_SHOW_TOUCHES) {
+         result += "SHOW_TOUCHES | ";
+     }
++    if (changes & CHANGE_FORCE_MOUSE_AS_TOUCH) {
++        result += "FORCE_MOUSE_AS_TOUCH | ";
++    }
+     if (changes & CHANGE_KEYBOARD_LAYOUTS) {
+         result += "KEYBOARD_LAYOUTS | ";
+     }
+diff --git a/services/inputflinger/dispatcher/InputDispatcher.cpp b/services/inputflinger/dispatcher/InputDispatcher.cpp
+index b93c3b51f..b6ca4579d 100644
+--- a/services/inputflinger/dispatcher/InputDispatcher.cpp
++++ b/services/inputflinger/dispatcher/InputDispatcher.cpp
+@@ -1601,8 +1601,7 @@ int32_t InputDispatcher::findTouchedWindowTargetsLocked(nsecs_t currentTime,
+ 
+     bool isSplit = tempTouchState.split;
+     bool switchedDevice = tempTouchState.deviceId >= 0 && tempTouchState.displayId >= 0 &&
+-            (tempTouchState.deviceId != entry.deviceId || tempTouchState.source != entry.source ||
+-             tempTouchState.displayId != displayId);
++            (tempTouchState.deviceId != entry.deviceId || tempTouchState.displayId != displayId);
+     bool isHoverAction = (maskedAction == AMOTION_EVENT_ACTION_HOVER_MOVE ||
+                           maskedAction == AMOTION_EVENT_ACTION_HOVER_ENTER ||
+                           maskedAction == AMOTION_EVENT_ACTION_HOVER_EXIT);
+diff --git a/services/inputflinger/include/InputReaderBase.h b/services/inputflinger/include/InputReaderBase.h
+index 879d26de3..835a239cd 100644
+--- a/services/inputflinger/include/InputReaderBase.h
++++ b/services/inputflinger/include/InputReaderBase.h
+@@ -157,6 +157,9 @@ struct InputReaderConfiguration {
+ 
+         // All devices must be reopened.
+         CHANGE_MUST_REOPEN = 1 << 31,
++        
++        // Force mouse as touch setting changed.
++        CHANGE_FORCE_MOUSE_AS_TOUCH = 1 << 90,
+     };
+ 
+     // Gets the amount of time to disable virtual keys after the screen is touched
+@@ -183,6 +186,9 @@ struct InputReaderConfiguration {
+ 
+     // True if pointer gestures are enabled.
+     bool pointerGesturesEnabled;
++    
++    // True if pointer touch emulation is enabled.
++    bool forceMouseAsTouch;
+ 
+     // Quiet time between certain pointer gesture transitions.
+     // Time to allow for all fingers or buttons to settle into a stable state before
+@@ -264,6 +270,7 @@ struct InputReaderConfiguration {
+             pointerVelocityControlParameters(1.0f, 500.0f, 3000.0f, 3.0f),
+             wheelVelocityControlParameters(1.0f, 15.0f, 50.0f, 4.0f),
+             pointerGesturesEnabled(true),
++            forceMouseAsTouch(false),
+             pointerGestureQuietInterval(100 * 1000000LL), // 100 ms
+             pointerGestureDragMinSwitchSpeed(50), // 50 pixels per second
+             pointerGestureTapInterval(150 * 1000000LL), // 150 ms
+diff --git a/services/inputflinger/reader/InputReader.cpp b/services/inputflinger/reader/InputReader.cpp
+index fc063f97a..1d64f4f41 100644
+--- a/services/inputflinger/reader/InputReader.cpp
++++ b/services/inputflinger/reader/InputReader.cpp
+@@ -680,6 +680,7 @@ void InputReader::dump(std::string& dump) {
+                          mConfig.wheelVelocityControlParameters.highThreshold,
+                          mConfig.wheelVelocityControlParameters.acceleration);
+ 
++    dump += StringPrintf(INDENT2 "PointerTouchEmulation: %s\n", toString(mConfig.forceMouseAsTouch));
+     dump += StringPrintf(INDENT2 "PointerGesture:\n");
+     dump += StringPrintf(INDENT3 "Enabled: %s\n", toString(mConfig.pointerGesturesEnabled));
+     dump += StringPrintf(INDENT3 "QuietInterval: %0.1fms\n",
+diff --git a/services/inputflinger/reader/mapper/CursorInputMapper.cpp b/services/inputflinger/reader/mapper/CursorInputMapper.cpp
+index 6f9fb1b5c..f3f0d81c7 100644
+--- a/services/inputflinger/reader/mapper/CursorInputMapper.cpp
++++ b/services/inputflinger/reader/mapper/CursorInputMapper.cpp
+@@ -159,7 +159,11 @@ void CursorInputMapper::configure(nsecs_t when, const InputReaderConfiguration*
+                 mParameters.mode = Parameters::MODE_POINTER;
+                 [[fallthrough]];
+             case Parameters::MODE_POINTER:
+-                mSource = AINPUT_SOURCE_MOUSE;
++                if (config->forceMouseAsTouch) {
++                    mSource = AINPUT_SOURCE_TOUCHSCREEN;
++                } else {
++                    mSource = AINPUT_SOURCE_MOUSE;
++                }
+                 mXPrecision = 1.0f;
+                 mYPrecision = 1.0f;
+                 mXScale = 1.0f;
+@@ -210,6 +214,17 @@ void CursorInputMapper::configure(nsecs_t when, const InputReaderConfiguration*
+         mWheelXVelocityControl.setParameters(config->wheelVelocityControlParameters);
+         mWheelYVelocityControl.setParameters(config->wheelVelocityControlParameters);
+     }
++    
++    if (!changes || (changes & InputReaderConfiguration::CHANGE_FORCE_MOUSE_AS_TOUCH)) {
++        if (mParameters.mode == Parameters::MODE_POINTER_RELATIVE) {
++            // Disable touch emulation for the pointer when Pointer Capture is enabled.
++            mSource = AINPUT_SOURCE_MOUSE_RELATIVE;
++        } else if (config->forceMouseAsTouch) {
++            mSource = AINPUT_SOURCE_TOUCHSCREEN;
++        } else {
++            mSource = AINPUT_SOURCE_MOUSE;
++        }
++    }
+ 
+     if (!changes || (changes & InputReaderConfiguration::CHANGE_DISPLAY_INFO)) {
+         mOrientation = DISPLAY_ORIENTATION_0;
+@@ -348,7 +363,7 @@ void CursorInputMapper::sync(nsecs_t when) {
+     int32_t displayId;
+     float xCursorPosition = AMOTION_EVENT_INVALID_CURSOR_POSITION;
+     float yCursorPosition = AMOTION_EVENT_INVALID_CURSOR_POSITION;
+-    if (mSource == AINPUT_SOURCE_MOUSE) {
++    if (mSource == AINPUT_SOURCE_MOUSE || mSource == AINPUT_SOURCE_TOUCHSCREEN) {
+         if (moved || scrolled || buttonsChanged) {
+             mPointerController->setPresentation(PointerControllerInterface::PRESENTATION_POINTER);
+ 
+@@ -403,7 +418,7 @@ void CursorInputMapper::sync(nsecs_t when) {
+         int32_t motionEventAction;
+         if (downChanged) {
+             motionEventAction = down ? AMOTION_EVENT_ACTION_DOWN : AMOTION_EVENT_ACTION_UP;
+-        } else if (down || (mSource != AINPUT_SOURCE_MOUSE)) {
++        } else if (down || (mSource != AINPUT_SOURCE_MOUSE && mSource != AINPUT_SOURCE_TOUCHSCREEN)) {
+             motionEventAction = AMOTION_EVENT_ACTION_MOVE;
+         } else {
+             motionEventAction = AMOTION_EVENT_ACTION_HOVER_MOVE;
+@@ -454,7 +469,7 @@ void CursorInputMapper::sync(nsecs_t when) {
+         ALOG_ASSERT(buttonState == currentButtonState);
+ 
+         // Send hover move after UP to tell the application that the mouse is hovering now.
+-        if (motionEventAction == AMOTION_EVENT_ACTION_UP && (mSource == AINPUT_SOURCE_MOUSE)) {
++        if (motionEventAction == AMOTION_EVENT_ACTION_UP && (mSource == AINPUT_SOURCE_MOUSE || mSource == AINPUT_SOURCE_TOUCHSCREEN)) {
+             NotifyMotionArgs hoverArgs(getContext()->getNextId(), when, getDeviceId(), mSource,
+                                        displayId, policyFlags, AMOTION_EVENT_ACTION_HOVER_MOVE, 0,
+                                        0, metaState, currentButtonState, MotionClassification::NONE,
+-- 
+2.25.1
+


### PR DESCRIPTION
fix https://github.com/waydroid/waydroid/issues/954

To activate it, you need to execute the command:
```bash
sudo waydroid shell settings put system force_mouse_as_touch 1
```
To deactivate, run the command:  
```bash
sudo waydroid shell settings put system force_mouse_as_touch 0
```
Switching works without restarting the session.  

Patch ported from BlissOS  
https://github.com/BlissRoms-x86/platform_frameworks_base/commit/1ae3ba5ec36d0247cb6b9c11d35565680d9b6626  
https://github.com/BlissRoms-x86/frameworks_native/commit/05148c9227fae71f22b9c12612fd45425c61d677  