### PR TITLE
Speed up patch application

### DIFF
--- a/waydroid-patches/apply-patches.sh
+++ b/waydroid-patches/apply-patches.sh
@@ -69,6 +69,7 @@ apply_patch() {
       echo -e ${reset}""${reset} 
       cd $top_dir
       project_revision=`repo info $current_project | grep 'Current revision: ' | sed 's/Current revision: //'`
+      project_log=`git log --max-count=1000 --pretty="format:%aD, %s" $project_revision..`
     fi
     previous_project=$current_project
 
@@ -82,7 +83,7 @@ apply_patch() {
     cd $top_dir/$current_project
     a=`grep "Date: " $pd/$i | sed -e "s/Date: //"`
     b=`grep "Subject: " $pd/$i | sed -e "s/Subject: //" | sed -e "s/^\[PATCH[^]]*\] //"`
-    c=`git log --pretty="format:%aD, %s" $project_revision.. | grep -F "$a, $b"`
+    c=`grep -F "$a, $b" <<< "$project_log"`
 
     if [[ "$c" == "" ]] ; then
       git am -3 $pd/$i >& /dev/null

--- a/waydroid-patches/apply-patches.sh
+++ b/waydroid-patches/apply-patches.sh
@@ -69,7 +69,7 @@ apply_patch() {
       echo -e ${reset}""${reset} 
       cd $top_dir
       project_revision=`repo info $current_project | grep 'Current revision: ' | sed 's/Current revision: //'`
-      project_log=`git log --max-count=1000 --pretty="format:%aD, %s" $project_revision..`
+      project_log=`git -C $current_project log --max-count=1000 --pretty="format:%aD, %s" $project_revision..`
     fi
     previous_project=$current_project
 


### PR DESCRIPTION
This speeds up patch application significantly by performing `git log` once, then grepping that output for any patches that may or may not be applied, rather than interrogating the full log every time.  Note that it only looks at the last 1000 commits, hopefully we never have more than 1000 patches landed on top of LineageOS.