### PR TITLE
libhidl: Un-urlencode patch subjects

### DIFF
--- a/waydroid-patches/base-patches-29/system/libhidl/0003-Don-t-wait-for-host-hwbinder.patch
+++ b/waydroid-patches/base-patches-29/system/libhidl/0003-Don-t-wait-for-host-hwbinder.patch
@@ -1,7 +1,7 @@
 From 122c7bc72a7251ad3ecebac5dbb690efd0688097 Mon Sep 17 00:00:00 2001
 From: Erfan Abdi <erfangplus@gmail.com>
 Date: Wed, 14 Apr 2021 11:25:37 +0430
-Subject: [PATCH] =?UTF-8?q?Don=E2=80=99t=20wait=20for=20host=20hwbinder?=
+Subject: [PATCH] Don’t wait for host hwbinder
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/waydroid-patches/base-patches-29/system/libhidl/0003-Don-t-wait-for-host-hwbinder.patch
+++ b/waydroid-patches/base-patches-29/system/libhidl/0003-Don-t-wait-for-host-hwbinder.patch
@@ -1,7 +1,7 @@
 From 122c7bc72a7251ad3ecebac5dbb690efd0688097 Mon Sep 17 00:00:00 2001
 From: Erfan Abdi <erfangplus@gmail.com>
 Date: Wed, 14 Apr 2021 11:25:37 +0430
-Subject: [PATCH] Don’t wait for host hwbinder
+Subject: [PATCH] Don't wait for host hwbinder
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/waydroid-patches/base-patches-30/system/libhidl/0003-Don-t-wait-for-host-hwbinder.patch
+++ b/waydroid-patches/base-patches-30/system/libhidl/0003-Don-t-wait-for-host-hwbinder.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Erfan Abdi <erfangplus@gmail.com>
 Date: Wed, 14 Apr 2021 11:25:37 +0430
-Subject: [PATCH] =?UTF-8?q?Don=E2=80=99t=20wait=20for=20host=20hwbinder?=
+Subject: [PATCH] Don’t wait for host hwbinder
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/waydroid-patches/base-patches-30/system/libhidl/0003-Don-t-wait-for-host-hwbinder.patch
+++ b/waydroid-patches/base-patches-30/system/libhidl/0003-Don-t-wait-for-host-hwbinder.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Erfan Abdi <erfangplus@gmail.com>
 Date: Wed, 14 Apr 2021 11:25:37 +0430
-Subject: [PATCH] Don’t wait for host hwbinder
+Subject: [PATCH] Don't wait for host hwbinder
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit


### PR DESCRIPTION
While `git am` can correctly un-urlencode these patch subjects, our previous patch detection fails on these patches, thinking they haven't been applied and attempting to re-apply them.