### PR TITLE
Set InputDeviceClass::DPAD class for Wayland virtual input device

### DIFF
--- a/waydroid-patches/base-patches-33/frameworks/native/0014-Set-InputDeviceClass-DPAD-class-for-Wayland-virtual-.patch
+++ b/waydroid-patches/base-patches-33/frameworks/native/0014-Set-InputDeviceClass-DPAD-class-for-Wayland-virtual-.patch
@@ -1,0 +1,27 @@
+From 029e7c8ae07c85e980a6d4d417568fe9bc95eeab Mon Sep 17 00:00:00 2001
+From: SupeChicken666 <me@supechicken666.dev>
+Date: Thu, 24 Jul 2025 04:19:38 +0000
+Subject: [PATCH 14/14] Set InputDeviceClass::DPAD class for Wayland virtual
+ input device
+
+Change-Id: Ib8d53e580a14f3ee60bd3832308edd64c3f01163
+Signed-off-by: SupeChicken666 <me@supechicken666.dev>
+---
+ services/inputflinger/reader/EventHub.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/services/inputflinger/reader/EventHub.cpp b/services/inputflinger/reader/EventHub.cpp
+index ba76cc4ede..fa86c23a5b 100644
+--- a/services/inputflinger/reader/EventHub.cpp
++++ b/services/inputflinger/reader/EventHub.cpp
+@@ -2348,6 +2348,7 @@ if (!isWayland) {
+     } else if (inputType == WL_INPUT_KEYBOARD) {
+         device->classes |= InputDeviceClass::KEYBOARD;
+         device->classes |= InputDeviceClass::ALPHAKEY;
++        device->classes |= InputDeviceClass::DPAD;
+ 
+         device->keyBitmask.set(BTN_MISC);
+         device->keyBitmask.set(KEY_OK);
+-- 
+2.50.1
+


### PR DESCRIPTION
Some apps (like TV version of Gboard) requires it to work properly.