### PR TITLE
Fix developer options tab crashing in ATV settings

### DIFF
--- a/waydroid-patches/base-patches-33/packages/apps/TvSettings/0001-Fix-developer-options-in-ATV-settings.patch
+++ b/waydroid-patches/base-patches-33/packages/apps/TvSettings/0001-Fix-developer-options-in-ATV-settings.patch
@@ -1,0 +1,26 @@
+From 2b77b0f7918e023df336d2a1b473534d5484f0a1 Mon Sep 17 00:00:00 2001
+From: SupeChicken666 <me@supechicken666.dev>
+Date: Thu, 10 Jul 2025 17:07:37 +0000
+Subject: [PATCH] Fix developer options in ATV settings
+
+Change-Id: I74bb098115df7b4dc35d1b619fed741aed37ed6a
+Signed-off-by: SupeChicken666 <me@supechicken666.dev>
+---
+ .../tv/settings/system/development/DevelopmentFragment.java      | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Settings/src/com/android/tv/settings/system/development/DevelopmentFragment.java b/Settings/src/com/android/tv/settings/system/development/DevelopmentFragment.java
+index 46b7493c1..d296324c5 100644
+--- a/Settings/src/com/android/tv/settings/system/development/DevelopmentFragment.java
++++ b/Settings/src/com/android/tv/settings/system/development/DevelopmentFragment.java
+@@ -1470,6 +1470,7 @@ public class DevelopmentFragment extends SettingsPreferenceFragment
+     }
+ 
+     private void updateUsbConfigurationValues() {
++        if (true) return;
+         final UsbManager manager = (UsbManager) getActivity().getSystemService(Context.USB_SERVICE);
+         if (mUsbConfiguration == null) {
+             return;
+-- 
+2.50.0
+


### PR DESCRIPTION
This fixes https://github.com/supechicken/waydroid-androidtv-build/issues/33:

> I noticed that if you enable developer settings in the standard way, the Settings app crashes when you move down to the developer settings option which is unlocked. This makes it impossible to access either the developer settings, or indeed any menu option which appears after the developer settings, as the Settings app crashes once that menu item is highlighted.