### PR TITLE
base-patches-33: WayDroidServices: Notify host on reboot/shutdown

### DIFF
--- a/waydroid-patches/base-patches-33/lineage-sdk/0006-WayDroidServices-Notify-host-on-reboot-shutdown.patch
+++ b/waydroid-patches/base-patches-33/lineage-sdk/0006-WayDroidServices-Notify-host-on-reboot-shutdown.patch
@@ -1,0 +1,125 @@
+From 211d38d600b3f4c97b9f96e72c8399b41a7c94e7 Mon Sep 17 00:00:00 2001
+From: SupeChicken666 <me@supechicken666.dev>
+Date: Thu, 7 May 2026 03:53:10 +0800
+Subject: [PATCH 6/6] WayDroidServices: Notify host on reboot/shutdown
+
+Signed-off-by: SupeChicken666 <me@supechicken666.dev>
+---
+ .../platform/internal/WayDroidService.java    | 23 +++++++++++++++++++
+ sdk/src/java/lineageos/waydroid/Hardware.java | 19 +++++++++++++++
+ .../java/lineageos/waydroid/IHardware.aidl    |  1 +
+ 3 files changed, 43 insertions(+)
+
+diff --git a/lineage/lib/main/java/org/lineageos/platform/internal/WayDroidService.java b/lineage/lib/main/java/org/lineageos/platform/internal/WayDroidService.java
+index 9cf6dd3c..827bf7ef 100644
+--- a/lineage/lib/main/java/org/lineageos/platform/internal/WayDroidService.java
++++ b/lineage/lib/main/java/org/lineageos/platform/internal/WayDroidService.java
+@@ -20,9 +20,11 @@ import android.app.Notification;
+ import android.app.PendingIntent;
+ import android.annotation.NonNull;
+ import android.content.ActivityNotFoundException;
++import android.content.BroadcastReceiver;
+ import android.content.ComponentName;
+ import android.content.Context;
+ import android.content.Intent;
++import android.content.IntentFilter;
+ import android.content.pm.ApplicationInfo;
+ import android.content.pm.PackageInstaller;
+ import android.content.pm.PackageManager;
+@@ -49,6 +51,8 @@ import com.android.internal.os.BackgroundThread;
+ 
+ import lineageos.app.LineageContextConstants;
+ import lineageos.waydroid.AppInfo;
++import lineageos.waydroid.IHardware;
++import lineageos.waydroid.Hardware;
+ import lineageos.waydroid.IPlatform;
+ import lineageos.waydroid.Platform;
+ import lineageos.waydroid.IUserMonitor;
+@@ -81,6 +85,7 @@ public class WayDroidService extends LineageSystemService {
+     private Context mContext;
+     private PackageManager mPm = null;
+     private UserMonitor mUM = null;
++    private Hardware mWaydroidHardware = null;
+     private Notifications mWaydroidNotifications = null;
+     private NotificationListenerService mSystemNotificationListener = null;
+ 
+@@ -110,6 +115,7 @@ public class WayDroidService extends LineageSystemService {
+         publishBinderService(LineageContextConstants.WAYDROID_PLATFORM_SERVICE, mPlatformService);
+         if (mContext != null) {
+             mUM = UserMonitor.getInstance(mContext);
++            mWaydroidHardware = Hardware.getInstance(mContext);
+             try {
+                 mWaydroidNotifications = Notifications.getInstance(mContext);
+             } catch (Exception e) {
+@@ -124,6 +130,9 @@ public class WayDroidService extends LineageSystemService {
+         if (mWaydroidNotifications != null) {
+             registerNotificationListener();
+         }
++        if (mWaydroidHardware != null) {
++            registerShutdownHandler();
++        }
+     }
+ 
+     @Override
+@@ -389,6 +398,20 @@ public class WayDroidService extends LineageSystemService {
+         });
+     }
+ 
++    private void registerShutdownHandler() {
++        IntentFilter filter = new IntentFilter();
++        BroadcastReceiver receiver = new BroadcastReceiver() {
++            @Override
++            public void onReceive(Context context, Intent intent) {
++                Log.i(TAG, "Android is shutting down");
++                mWaydroidHardware.shutdownRequest(SystemProperties.get("sys.shutdown.requested"));
++            }
++        };
++
++        filter.addAction(Intent.ACTION_SHUTDOWN);
++        mContext.registerReceiver(receiver, filter, Context.RECEIVER_NOT_EXPORTED);
++    }
++
+     private String _getAppName(String packageName) {
+         if (mPm == null || mContext == null)
+             return "";
+diff --git a/sdk/src/java/lineageos/waydroid/Hardware.java b/sdk/src/java/lineageos/waydroid/Hardware.java
+index 3dfda498..328f9a59 100644
+--- a/sdk/src/java/lineageos/waydroid/Hardware.java
++++ b/sdk/src/java/lineageos/waydroid/Hardware.java
+@@ -150,4 +150,23 @@ public class Hardware {
+         }
+         return;
+     }
++
++    public void shutdownRequest(String reason) {
++        IHardware service = getService();
++        if (service == null) {
++            return;
++        }
++        try {
++            service.shutdownRequest(reason);
++        } catch (RemoteException | RuntimeException e) {
++            if (reason != null && reason.startsWith("1")) {
++                // Fallback to reboot() if the call was not implemented on the host side
++                Log.d(TAG, "IHardware.shutdownRequest not implemented, falling back to IHardware.reboot");
++                reboot();
++            } else {
++                Log.e(TAG, e.getLocalizedMessage(), e);
++            }
++        }
++        return;
++    }
+ }
+diff --git a/sdk/src/java/lineageos/waydroid/IHardware.aidl b/sdk/src/java/lineageos/waydroid/IHardware.aidl
+index ec7c8e11..1b2a3963 100644
+--- a/sdk/src/java/lineageos/waydroid/IHardware.aidl
++++ b/sdk/src/java/lineageos/waydroid/IHardware.aidl
+@@ -24,4 +24,5 @@ interface IHardware {
+     void reboot();
+     void upgrade(String system_zip, int system_time, String vendor_zip, int vendor_time);
+     void upgrade2(String system_zip, long system_time, String vendor_zip, long vendor_time);
++    oneway void shutdownRequest(String reason);
+ }
+-- 
+2.54.0
+


### PR DESCRIPTION
Related: https://github.com/waydroid/waydroid/pull/2305

Add `IHardware.shutdownRequest()` method for notifying host when Android is shutting down or rebooting, and register a broadcast receiver in `WaydroidServices` to monitor shutdown intents

This allow us to restart the container/terminate `waydroid session` automatically on Android reboot/shutdown

(For reboot only) When `IHardware.shutdownRequest()` is unavailable, it will fallback to the existing `IHardware.reboot()` call and do a immediate restart without waiting for Android to shutdown gracefully